### PR TITLE
Update LiaScript link for chapter Sensorfusion-I

### DIFF
--- a/08_Sensorfusion_I/08_Datenfusion.md
+++ b/08_Sensorfusion_I/08_Datenfusion.md
@@ -13,7 +13,7 @@ import:   https://github.com/liascript/CodeRunner
 
 -->
 
-[![LiaScript](https://raw.githubusercontent.com/LiaScript/LiaScript/master/badges/course.svg)](https://liascript.github.io/course/?https://raw.githubusercontent.com/TUBAF-IfI-LiaScript/VL_SoftwareprojektRobotik/refs/heads/master/08_Datenfusion/08_Datenfusion.md)
+[![LiaScript](https://raw.githubusercontent.com/LiaScript/LiaScript/master/badges/course.svg)](https://liascript.github.io/course/?https://raw.githubusercontent.com/TUBAF-IfI-LiaScript/VL_SoftwareprojektRobotik/master/08_Sensorfusion_I/08_Datenfusion.md)
 
 # Datenfusion
 


### PR DESCRIPTION
Der Lia-Script course link unter Sensorfusion I hat zu einer 404-Seite verlinkt, da er wahrscheinlich einfach veraltet war. Ich habe ihn aktualisiert, bei mir geht es jetzt mit dem Neuen wieder.